### PR TITLE
Incorrect class fix

### DIFF
--- a/src/pocketmine/entity/Lightning.php
+++ b/src/pocketmine/entity/Lightning.php
@@ -24,8 +24,8 @@ namespace pocketmine\entity;
 use pocketmine\block\Liquid;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\math\Vector3;
-use pocketmine\network\protocol\AddEntityPacket;
-use pocketmine\network\protocol\ExplodePacket;
+use pocketmine\network\mcpe\protocol\AddEntityPacket;
+use pocketmine\network\mcpe\protocol\ExplodePacket;
 use pocketmine\item\Item as ItemItem;
 use pocketmine\Player;
 


### PR DESCRIPTION
This P.R., fixes the frequent critical error caused by incorrect class when lightning tries to spawn.